### PR TITLE
DE40893 - Handle Data Hub permissions in the scheduler UI

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -23,7 +23,7 @@
 
 			<h2>d2l-custom-ads-scheduler</h2>
 			<d2l-demo-snippet>
-				<d2l-manage-schedules schedules='[{"name":"Schedule1","typeId":"1","frequencyId":"1","startDate":"2020-01-02","endDate":"2020-02-05","isEnabled":1,"scheduleId":1},{"name":"Schedule 2","typeId":"2","frequencyId":"4","startDate":"2020-02-02","endDate":"2020-11-22","isEnabled":0,"scheduleId":2}]'></d2l-manage-schedules>
+				<d2l-manage-schedules  schedules='[{"name":"Schedule1","typeId":"1","frequencyId":"1","startDate":"2020-01-02","endDate":"2020-02-05","isEnabled":1,"scheduleId":1},{"name":"Schedule 2","typeId":"2","frequencyId":"4","startDate":"2020-02-02","endDate":"2020-11-22","isEnabled":0,"scheduleId":2}]'></d2l-manage-schedules>
 			</d2l-demo-snippet>
 
 			<h2>d2l-custom-ads-scheduler - No Data</h2>

--- a/demo/index.html
+++ b/demo/index.html
@@ -21,9 +21,14 @@
 	<body>
 		<d2l-demo-page page-title="d2l-custom-ads-scheduler">
 
-			<h2>d2l-custom-ads-scheduler</h2>
+			<h2>d2l-custom-ads-scheduler - With Data Hub access</h2>
 			<d2l-demo-snippet>
-				<d2l-manage-schedules  schedules='[{"name":"Schedule1","typeId":"1","frequencyId":"1","startDate":"2020-01-02","endDate":"2020-02-05","isEnabled":1,"scheduleId":1},{"name":"Schedule 2","typeId":"2","frequencyId":"4","startDate":"2020-02-02","endDate":"2020-11-22","isEnabled":0,"scheduleId":2}]'></d2l-manage-schedules>
+				<d2l-manage-schedules data-hub-access schedules='[{"name":"Schedule1","typeId":"1","frequencyId":"1","startDate":"2020-01-02","endDate":"2020-02-05","isEnabled":1,"scheduleId":1},{"name":"Schedule 2","typeId":"2","frequencyId":"4","startDate":"2020-02-02","endDate":"2020-11-22","isEnabled":0,"scheduleId":2}]'></d2l-manage-schedules>
+			</d2l-demo-snippet>
+
+			<h2>d2l-custom-ads-scheduler - No Data Hub access</h2>
+			<d2l-demo-snippet>
+				<d2l-manage-schedules schedules='[{"name":"Schedule1","typeId":"1","frequencyId":"1","startDate":"2020-01-02","endDate":"2020-02-05","isEnabled":1,"scheduleId":1},{"name":"Schedule 2","typeId":"2","frequencyId":"4","startDate":"2020-02-02","endDate":"2020-11-22","isEnabled":0,"scheduleId":2}]'></d2l-manage-schedules>
 			</d2l-demo-snippet>
 
 			<h2>d2l-custom-ads-scheduler - No Data</h2>

--- a/src/components/d2l-manage-schedules.js
+++ b/src/components/d2l-manage-schedules.js
@@ -21,6 +21,10 @@ class ManagerSchedules extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
+			dataHubAccess: {
+				type: Boolean,
+				attribute: 'data-hub-access'
+			},
 			schedules: {
 				type: Array
 			},
@@ -91,6 +95,7 @@ class ManagerSchedules extends LocalizeMixin(LitElement) {
 		this.manageSchedulesService = ManageSchedulesServiceFactory.getManageSchedulesService();
 
 		this.schedules = Array();
+		this.dataHubAccess = false;
 	}
 
 	render() {
@@ -144,12 +149,7 @@ class ManagerSchedules extends LocalizeMixin(LitElement) {
 				</d2l-button-icon>
 				<d2l-dropdown-menu>
 					<d2l-menu>
-						<d2l-menu-item
-							id="dropdown-edit-${schedule.scheduleId}"
-							schedule-id="${ schedule.scheduleId }"
-							text="${  this.localize('actionEdit') }"
-							@click="${ this._handleEdit }">
-						</d2l-menu-item>
+						${ this._renderEditDropdownOption(schedule.scheduleId) }
 						<d2l-menu-item
 							id="dropdown-log-${schedule.scheduleId}"
 							schedule-id="${ schedule.scheduleId }"
@@ -166,6 +166,33 @@ class ManagerSchedules extends LocalizeMixin(LitElement) {
 				</d2l-dropdown-menu>
 			</d2l-dropdown>
 		`;
+	}
+
+	_renderAddNewButton() {
+		if (this.dataHubAccess) {
+			return html`
+				<d2l-button-subtle
+					id="add-new"
+					class="add-new-button"
+					icon="tier1:plus-large-thick"
+					text="${ this.localize('actionNew') }"
+					@click=${ this._handleNew }>
+				</d2l-button-subtle>
+			`;
+		}
+	}
+
+	_renderEditDropdownOption(scheduleId) {
+		if (this.dataHubAccess) {
+			return html`
+				<d2l-menu-item
+					id="dropdown-edit-${scheduleId}"
+					schedule-id="${ scheduleId }"
+					text="${  this.localize('actionEdit') }"
+					@click="${ this._handleEdit }">
+				</d2l-menu-item>
+			`;
+		}
 	}
 
 	_renderEmptyIllustration() {
@@ -212,13 +239,7 @@ class ManagerSchedules extends LocalizeMixin(LitElement) {
 		} else {
 			return html`
 				${ baseTemplate }
-				<d2l-button-subtle
-					id="add-new"
-					class="add-new-button"
-					icon="tier1:plus-large-thick"
-					text="${ this.localize('actionNew') }"
-					@click=${ this._handleNew }>
-				</d2l-button-subtle>
+				${ this._renderAddNewButton() }
 				${ this._renderTable() }
 			`;
 		}

--- a/src/components/d2l-manage-schedules.js
+++ b/src/components/d2l-manage-schedules.js
@@ -11,6 +11,7 @@ import './nothing-here-illustration';
 import { bodyStandardStyles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { frequencies, types } from '../constants';
+import { classMap } from 'lit-html/directives/class-map.js';
 import { d2lTableStyles } from '../styles/d2lTableStyles';
 import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime';
 import { getLocalizeResources } from '../localization.js';
@@ -56,6 +57,10 @@ class ManagerSchedules extends LocalizeMixin(LitElement) {
 
 			.description-text {
 				margin-bottom: 0px;
+			}
+
+			.no-data-hub-access {
+				margin-bottom: 18px;
 			}
 
 			.message--empty-table {
@@ -214,7 +219,7 @@ class ManagerSchedules extends LocalizeMixin(LitElement) {
 		const isEmpty = this.schedules.length === 0;
 
 		const baseTemplate = html`
-			<div class="description-text d2l-body-standard">
+			<div class="description-text d2l-body-standard ${classMap({ 'no-data-hub-access': !this.dataHubAccess })}">
 				${ this.localize('schedulerDesc') }
 			</div>
 			<d2l-alert-toast id="error" type="critical">

--- a/src/services/addEditScheduleService.js
+++ b/src/services/addEditScheduleService.js
@@ -3,7 +3,11 @@ import { Scheduler } from '../api/scheduler';
 export class AddEditScheduleService {
 
 	static async getAdvancedDataSets() {
-		const dataSets = await Scheduler.getDataSets();
+		const dataSets = await Scheduler.getDataSets().catch(ex => {
+			window.console.log(ex.detail);
+			return [];
+		});
+
 		return dataSets.filter(ds => {
 			return ds.Category && ds.Category === 'AdvancedDataSets';
 		});

--- a/src/services/addEditScheduleService.js
+++ b/src/services/addEditScheduleService.js
@@ -3,12 +3,12 @@ import { Scheduler } from '../api/scheduler';
 export class AddEditScheduleService {
 
 	static async getAdvancedDataSets() {
-		const dataSets = await Scheduler.getDataSets().catch(ex => {
-			window.console.log(ex.detail);
+		const result = await Scheduler.getDataSets();
+		if (result.status === 403) {
+			window.console.error(result.detail);
 			return [];
-		});
-
-		return dataSets.filter(ds => {
+		}
+		return result.filter(ds => {
 			return ds.Category && ds.Category === 'AdvancedDataSets';
 		});
 	}


### PR DESCRIPTION
This started out as a simple change to handle when the LMS returns a 403 when trying to query the Advanced Data Sets, without Data Hub access being granted to the user (discovered because it is OFF by default, for Administrators).

However, in this case, it makes more sense that the user be allowed to view/enable/disable schedules and view logs, but NOT add/edit schedules. (Assumptions verified by Josh)

These changes accept a new boolean attribute for the manage-schedules page, which controls whether the Add/Edit options are shown to the user.

This is the UI-side of the permissions defect ticket, and the LMS changes can be found in this PR: https://github.com/Brightspace/lms/pull/2392

