### PR TITLE
DE41345 Incorrect error messages

### DIFF
--- a/src/components/d2l-delivery-method.js
+++ b/src/components/d2l-delivery-method.js
@@ -90,8 +90,8 @@ class DeliveryMethod extends LocalizeMixin(LitElement) {
 		this.errorText = this.localize('step2.validation.prefix');
 
 		const invalidProperties = [];
-		if (this.invalidDeliveryMethod) invalidProperties.push(this.localize('step3.deliveryMethod.errorMessage'));
-		if (this.invalidFolder) invalidProperties.push(this.localize('step3.folder.errorMessage'));
+		if (this.invalidDeliveryMethod) invalidProperties.push(this.localize('step3.deliveryMethod.label'));
+		if (this.invalidFolder) invalidProperties.push(this.localize('step3.folder.label'));
 
 		for (let i = 0; i < invalidProperties.length; i++) {
 			this.errorText += `${ i === 0 ? ' ' : ', ' }${ invalidProperties[i] }`;


### PR DESCRIPTION
Most of this defect is fixed in another PR:
https://github.com/Brightspace/custom-ads-scheduler/pull/51

This PR is just changing the alert for step 3 to only say the field name, similar as other steps.