### PR TITLE
Sazim/US12921 role selector permission check

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@brightspace-ui-labs/pagination": "^1",
-    "@brightspace-ui-labs/role-selector": "^1.1.3",
+    "@brightspace-ui-labs/role-selector": "^1.1.4",
     "@brightspace-ui-labs/wizard": "^1.0.0",
     "@brightspace-ui/core": "^1.92.0",
     "@brightspace-ui/intl": "^3.0.11",

--- a/src/api/scheduler.js
+++ b/src/api/scheduler.js
@@ -45,6 +45,10 @@ export class Scheduler {
 	static async _fetch(url, options) {
 		return await fetch(url, options)
 			.then(response => {
+				if (response.status === 403) {
+					return [];
+				}
+
 				if (!response.ok) {
 					throw Error(response.statusText);
 				}


### PR DESCRIPTION
When the login user does not have the View Users Enrolement permission, `GET /d2l/api/lp/(version)/(orgUnitId)/roles/`  URL responses with a Forbidden status. Changes in this PR is to handle the forbidden response status.
