### PR TITLE
remove visual-diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm run lint:lit
 ### Testing
 
 ```shell
-# lint, unit test and visual-diff test
+# lint, unit test
 npm test
 
 # lint only
@@ -57,15 +57,20 @@ npm run test:headless:watch
 
 This repo uses the [@brightspace-ui/visual-diff utility](https://github.com/BrightspaceUI/visual-diff/) to compare current snapshots against a set of golden snapshots stored in source control.
 
+The golden snapshots in source control must be updated by Github Actions.  If your PR's code changes result in visual differences, a PR with the new goldens will be automatically opened for you against your branch.
+
+If you'd like to run the tests locally to help troubleshoot or develop new tests, you can use these commands:
+
 ```shell
+# Install dependencies locally
+npm i mocha -g
+npm i @brightspace-ui/visual-diff puppeteer --no-save
 # run visual-diff tests
-npm run test:diff
-
+mocha './test/**/*.visual-diff.js' -t 10000
 # subset of visual-diff tests:
-npm run test:diff -- -g some-pattern
-
+mocha './test/**/*.visual-diff.js' -t 10000 -g some-pattern
 # update visual-diff goldens
-npm run test:diff:golden
+mocha './test/**/*.visual-diff.js' -t 10000 --golden
 ```
 
 ## Versioning, Releasing & Deploying

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "lint:lit": "lit-analyzer custom-ads-scheduler.js demo test",
     "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --open --watch",
     "test": "npm run lint && npm run test:headless && npm run test:diff",
-    "test:diff": "mocha ./**/*.visual-diff.js -t 40000",
-    "test:diff:golden": "mocha ./**/*.visual-diff.js -t 40000 --golden",
-    "test:diff:golden:commit": "commit-goldens",
     "test:headless": "karma start",
     "test:headless:watch": "karma start --auto-watch=true --single-run=false",
     "test:sauce": "karma start karma.sauce.conf.js"
@@ -26,9 +23,9 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@brightspace-ui/visual-diff": "^2",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^4",
+    "@webcomponents/webcomponentsjs": "^2",
     "babel-eslint": "^10",
     "deepmerge": "^4",
     "es-dev-server": "^2",
@@ -40,7 +37,6 @@
     "frau-ci": "^1",
     "karma-sauce-launcher": "^4",
     "lit-analyzer": "^1",
-    "puppeteer": "^5",
     "sinon": "^9.0.2"
   },
   "dependencies": {
@@ -49,7 +45,6 @@
     "@brightspace-ui-labs/wizard": "^1.2.2",
     "@brightspace-ui/core": "^1.92.0",
     "@brightspace-ui/intl": "^3.0.11",
-    "@webcomponents/webcomponentsjs": "^2",
     "lit-element": "^2"
   }
 }


### PR DESCRIPTION
We're in the process of migrating all the visual-diff usages to use GitHub Actions. This repo looks like it has some visual-diff tests written but visual-diff was never enabled/run.

So what I've done here is remove the reference to the old visual-diff from `package.json`, updated the README and then next week there'll be a blog post outlining how to use visual-diff with GitHub Actions. When you're ready to take that on, it should be super easy to enable them.