### PR TITLE
Bump node version used in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Install dependencies
         run: npm install
       - name: Lint (JavaScript)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
           persist-credentials: false
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14.x'
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@master
         with:

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14.x'
       - name: Install Dependencies
         run: npm install
       - name: Visual Diff Tests

--- a/test/custom-ads-scheduler.visual-diff.html
+++ b/test/custom-ads-scheduler.visual-diff.html
@@ -7,6 +7,10 @@
 			import '../src/components/d2l-manage-schedules.js';
 			import '../src/components/d2l-schedule-logs.js';
 			import '../src/components/d2l-wizard-manager.js';
+			import sinon from 'sinon';
+
+			const newToday = new Date('2021-05-25T12:00Z');
+			sinon.useFakeTimers({ now: newToday.getTime(), toFake: ['Date'] });
 		</script>
 		<script>
 			window.demo = true;


### PR DESCRIPTION
We are planning to bump the version of Puppeteer used in visual-diff and so this PR is to bump the node version to the current LTS version.